### PR TITLE
tag release

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,40 @@
+name: tag-release
+
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - 'v*' # This includes only tags starting with v
+
+jobs:
+  build-source:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    # Dedicated environments with protections for publishing are strongly recommended.
+    environment:
+      name: release
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: "pip"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+    - name: Build source Python package
+      run: python -m build -s -o dist .
+    - name: Publish release distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          ./dist/**
+
+


### PR DESCRIPTION
Tag release as discussed

Note that this is exactly the same action as in cocopp. I could thus technically make it a shared workflow, but that is a bit annoying, because you have to pass around secrets. But if you think it would be worth it, especially if there are more simple python packages to be released in the same way, one could think about it.

My own version is here, with only partly reused code to avoid some hassle:
* reusable workflow for python release: https://github.com/TAI-src/.github/blob/main/.github/workflows/release-python.yml
* usage example: https://github.com/TAI-src/jaix/blob/main/.github/workflows/cd.yml